### PR TITLE
PASSWORD_DEFAULT hashing

### DIFF
--- a/authentication.php
+++ b/authentication.php
@@ -19,7 +19,7 @@ $database = $env['database'];
 
 
          if ($result->num_rows == 0) {
-             $password = password_hash($_POST["psw"], PASSWORD_BCRYPT);
+             $password = password_hash($_POST["psw"], PASSWORD_DEFAULT);
 
              $username = $_POST['uname'];
              $query = "INSERT INTO auth (username, password) VALUES (?, ?)";


### PR DESCRIPTION
https://www.php.net/manual/en/function.password-hash.php

Typically best practise with password security is not to do it at all, but if you must, follow the defaults imo. At least then you can blame PHP for not updating it, and you'll get what they deem is most secure without having to concern yourself.